### PR TITLE
Rails 6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@ Querrel makes it easy to query multiple databases in parallel (threads) using Ac
 
 ## Installation
 
+Querrel version >= 2.0 is required for Rails 6 (and does not support earlier versions).  For Rails versions 5.x and earlier, use version 1.4.
+
 Add this line to your application's Gemfile:
 
-    gem 'querrel'
+    gem 'querrel', '~> 2.0'		# Rails 6
+    
+or
+
+    gem 'querrel', '~> 1.4'		# Rails 5 and earlier
 
 And then execute:
 

--- a/lib/querrel/connection_resolver.rb
+++ b/lib/querrel/connection_resolver.rb
@@ -1,32 +1,33 @@
 module Querrel
   class ConnectionResolver
-    attr_accessor :resolver
 
     def initialize(conns, db_names)
       if db_names
-        base_spec = ActiveRecord::Base.connection_config
+        base_spec = ActiveRecord::Base.connection_db_config.configuration_hash
 
         specs = conns.map do |c|
-          [c, base_spec.dup.update(database: c)]
+          [ c.to_s, base_spec.dup.update(database: c) ]
         end
-        specs = Hash[specs]
+        @specs = Hash[specs]
       else
         case conns
         when Hash
-          specs = conns
+          @specs = conns
         when Array
-          conns.map!(&:to_s)
-          specs = ActiveRecord::Base.configurations.select{ |n, _| conns.include?(n.to_s) }
+          specs = conns.map do |c|
+            [ c.to_s, ActiveRecord::Base.configurations.find_db_config(c).configuration_hash ]
+          end
+          @specs = Hash[specs]
         end
       end
-
-      @resolver = ActiveRecord::ConnectionAdapters::ConnectionSpecification::Resolver.new(specs)
     end
 
-    [:configurations, :spec, :resolve].each do |m|
-      define_method(m) do |*args, &block|
-        @resolver.send(m, *args, &block)
-      end
+    def resolve(db)
+      @specs[db.to_s]
+    end
+
+    def configurations
+      @specs
     end
   end
 end

--- a/lib/querrel/querreller.rb
+++ b/lib/querrel/querreller.rb
@@ -38,20 +38,8 @@ module Querrel
       pool.do_your_thang!
     end
 
-    def retrieve_connection_spec(db, resolver)
-      resolver.spec(db.to_sym)
-    end
-
     def retrieve_connection_config(db, resolver)
       resolver.resolve(db.to_sym)
-    end
-
-    def while_connected_to(db, resolver, &b)
-      conf = resolver.spec(db.to_sym)
-      pool = ActiveRecord::ConnectionAdapters::ConnectionPool.new(conf)
-      pool.with_connection(&b)
-    ensure
-      pool.disconnect!
     end
   end
 end

--- a/lib/querrel/version.rb
+++ b/lib/querrel/version.rb
@@ -1,3 +1,3 @@
 module Querrel
-  VERSION = "1.4.0"
+  VERSION = "2.0.0"
 end

--- a/querrel.gemspec
+++ b/querrel.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 4.0"
+  spec.add_runtime_dependency "activerecord", "~> 6.0"
 
-  spec.add_development_dependency "bundler", "~> 1.6"
+  spec.add_development_dependency "bundler", ">= 2.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "sqlite3", "~> 1.3.5"
   spec.add_development_dependency "database_rewinder", "~> 0"

--- a/test/instance_test.rb
+++ b/test/instance_test.rb
@@ -48,7 +48,7 @@ class InstanceTest < Querrel::Test
 
     @q.run do
       s.synchronize do
-        configs_actual << Product.connection_config
+        configs_actual << Product.connection_db_config.configuration_hash
       end
     end
 

--- a/test/non_instance_test.rb
+++ b/test/non_instance_test.rb
@@ -48,7 +48,7 @@ class NonInstanceTest < Querrel::Test
     configs_actual = []
     Querrel.run(on: @dbs) do
       s.synchronize do
-        configs_actual << Product.connection_config
+        configs_actual << Product.connection_db_config.configuration_hash
       end
     end
 

--- a/test/setup/active_record_config.rb
+++ b/test/setup/active_record_config.rb
@@ -9,8 +9,8 @@ ActiveRecord::Base.configurations = YAML.load(database_yml)
 ActiveRecord::Base.logger = Logger.new(File.join(File.dirname(__FILE__), "debug.log"))
 
 # load schema and fixtures to each db
-ActiveRecord::Base.configurations.keys.each do |c|
-  ActiveRecord::Base.establish_connection(c.to_sym)
+ActiveRecord::Base.configurations.configurations.each do |config|
+  ActiveRecord::Base.establish_connection(config)
   ActiveRecord::Migration.suppress_messages do
     load('schema.rb')
   end
@@ -21,8 +21,10 @@ ActiveRecord::Base.establish_connection(ENV['DB'] || :sqlite_db_0)
 
 require "active_support"
 require "database_rewinder"
+require "database_rewinder/cleaner"
 
 # configure DatabaseRewinder
-ActiveRecord::Base.configurations.keys.each do |c|
-  DatabaseRewinder[c]
+DatabaseRewinder.init
+ActiveRecord::Base.configurations.configurations.each do |config|
+  DatabaseRewinder[config.env_name]
 end


### PR DESCRIPTION
Rails 6 refactors active record heavily and removes ActiveRecord::ConnectionAdapters::ConnectionSpecification, breaking querrel

This PR updates querrel to work with Rails 6.  It is not backwards compatible, the existing querrel 1.4 should still be used with Rails 5 and earlier. Version number is bumped to 2.0.0 due to this incompatibility.
  